### PR TITLE
adapted code to hrdf-parser option to find

### DIFF
--- a/src/routing/connections.rs
+++ b/src/routing/connections.rs
@@ -154,7 +154,12 @@ pub fn get_operating_journeys(
                         .unwrap()
                 })
                 .flatten()
-                .map(|&journey_id| data_storage.journeys().find(journey_id))
+                .map(|&journey_id| {
+                    data_storage
+                        .journeys()
+                        .find(journey_id)
+                        .unwrap_or_else(|| panic!("Journey {:?} not found.", journey_id))
+                })
                 .collect()
         })
 }
@@ -166,9 +171,18 @@ pub fn get_exchange_time(
     journey_id_2: i32,
     departure_at: NaiveDateTime,
 ) -> i16 {
-    let stop = data_storage.stops().find(stop_id);
-    let journey_1 = data_storage.journeys().find(journey_id_1);
-    let journey_2 = data_storage.journeys().find(journey_id_2);
+    let stop = data_storage
+        .stops()
+        .find(stop_id)
+        .unwrap_or_else(|| panic!("Stop {:?} not found.", stop_id));
+    let journey_1 = data_storage
+        .journeys()
+        .find(journey_id_1)
+        .unwrap_or_else(|| panic!("Journey {:?} not found.", journey_id_1));
+    let journey_2 = data_storage
+        .journeys()
+        .find(journey_id_2)
+        .unwrap_or_else(|| panic!("Journey {:?} not found.", journey_id_2));
 
     // Fahrtpaarbezogene Umsteigezeiten /-\ Journey pair-related exchange times.
     if let Some(exchange_time) = exchange_time_journey_pair(
@@ -192,6 +206,7 @@ pub fn get_exchange_time(
         return data_storage
             .exchange_times_administration()
             .find(id)
+            .unwrap_or_else(|| panic!("Exchange time administration {:?} not found.", id))
             .duration();
     }
 
@@ -215,6 +230,7 @@ pub fn get_exchange_time(
         return data_storage
             .exchange_times_administration()
             .find(id)
+            .unwrap_or_else(|| panic!("Exchange time administration {:?} not found.", id))
             .duration();
     }
 
@@ -249,10 +265,16 @@ fn exchange_time_journey_pair(
     ) - 1;
 
     for &id in exchange_times {
-        let exchange_time = data_storage.exchange_times_journey().find(id);
+        let exchange_time = data_storage
+            .exchange_times_journey()
+            .find(id)
+            .unwrap_or_else(|| panic!("Exchange time journey {:?} not found.", id));
 
         if let Some(bit_field_id) = exchange_time.bit_field_id() {
-            let bit_field = data_storage.bit_fields().find(bit_field_id);
+            let bit_field = data_storage
+                .bit_fields()
+                .find(bit_field_id)
+                .unwrap_or_else(|| panic!("Bitfield {:?} not found.", bit_field_id));
 
             if bit_field.bits()[index] == 1 {
                 return Some(exchange_time.duration());

--- a/src/routing/display.rs
+++ b/src/routing/display.rs
@@ -9,7 +9,7 @@ impl RouteResult {
             let journey = section.journey(data_storage);
 
             if journey.is_none() {
-                let stop = data_storage.stops().find(section.arrival_stop_id());
+                let stop = data_storage.stops().find(section.arrival_stop_id()).unwrap_or_else(|| panic!("Stop {:?} not found.", section.arrival_stop_id()));
                 println!("Approx. {}-minute walk to {}", section.duration().unwrap(), stop.name());
                 continue;
             }

--- a/src/routing/exploration.rs
+++ b/src/routing/exploration.rs
@@ -83,9 +83,9 @@ fn can_explore_connections(
     let stop = if let Some(stop) = stop {
         stop
     } else {
+        log::warn!("Stop: {} not found.", stop_id);
         return false;
     };
-    // .unwrap_or_else(|| panic!("Stop {:?} not found.", stop_id));
 
     if !stop.can_be_used_as_exchange_point() {
         // The arrival stop of the last RouteSection of a journey is not necessarily usable for exchange, hence the check.

--- a/src/routing/exploration.rs
+++ b/src/routing/exploration.rs
@@ -80,6 +80,12 @@ fn can_explore_connections(
 ) -> bool {
     let stop_id = route.arrival_stop_id();
     let stop = data_storage.stops().find(stop_id);
+    let stop = if let Some(stop) = stop {
+        stop
+    } else {
+        return false;
+    };
+    // .unwrap_or_else(|| panic!("Stop {:?} not found.", stop_id));
 
     if !stop.can_be_used_as_exchange_point() {
         // The arrival stop of the last RouteSection of a journey is not necessarily usable for exchange, hence the check.

--- a/src/routing/models.rs
+++ b/src/routing/models.rs
@@ -62,7 +62,12 @@ impl RouteSection {
     // Functions
 
     pub fn journey<'a>(&'a self, data_storage: &'a DataStorage) -> Option<&Journey> {
-        self.journey_id.map(|id| data_storage.journeys().find(id))
+        self.journey_id.map(|id| {
+            data_storage
+                .journeys()
+                .find(id)
+                .unwrap_or_else(|| panic!("Journey {:?} not found.", id))
+        })
     }
 }
 
@@ -289,7 +294,12 @@ impl RouteSectionResult {
     // Functions
 
     pub fn journey<'a>(&'a self, data_storage: &'a DataStorage) -> Option<&Journey> {
-        self.journey_id.map(|id| data_storage.journeys().find(id))
+        self.journey_id.map(|id| {
+            data_storage
+                .journeys()
+                .find(id)
+                .unwrap_or_else(|| panic!("Journey {:?} not found.", id))
+        })
     }
 
     pub fn is_walking_trip(&self) -> bool {

--- a/src/routing/route_impl.rs
+++ b/src/routing/route_impl.rs
@@ -15,7 +15,10 @@ impl Route {
         date: NaiveDate,
         is_departure_date: bool,
     ) -> Option<Route> {
-        let journey = data_storage.journeys().find(journey_id);
+        let journey = data_storage
+            .journeys()
+            .find(journey_id)
+            .unwrap_or_else(|| panic!("Journey {:?} not found.", journey_id));
 
         if journey.is_last_stop(self.arrival_stop_id(), false) {
             return None;
@@ -127,8 +130,14 @@ impl RouteSection {
     }
 
     pub fn to_route_section_result(&self, data_storage: &DataStorage) -> RouteSectionResult {
-        let departure_stop = data_storage.stops().find(self.departure_stop_id());
-        let arrival_stop = data_storage.stops().find(self.arrival_stop_id());
+        let departure_stop = data_storage
+            .stops()
+            .find(self.departure_stop_id())
+            .unwrap_or_else(|| panic!("Stop {:?} not found.", self.departure_stop_id()));
+        let arrival_stop = data_storage
+            .stops()
+            .find(self.arrival_stop_id())
+            .unwrap_or_else(|| panic!("Stop {:?} not found.", self.arrival_stop_id()));
 
         let (departure_at, arrival_at) = if self.journey_id().is_some() {
             let departure_at = self

--- a/src/routing/utils.rs
+++ b/src/routing/utils.rs
@@ -22,7 +22,12 @@ pub fn get_stop_connections(
     data_storage
         .stop_connections_by_stop_id()
         .get(&stop_id)
-        .map(|ids| data_storage.stop_connections().resolve_ids(ids))
+        .map(|ids| {
+            data_storage
+                .stop_connections()
+                .resolve_ids(ids)
+                .unwrap_or_else(|| panic!("Ids {:?} not found.", ids))
+        })
 }
 
 pub fn get_routes_to_ignore(data_storage: &DataStorage, route: &Route) -> FxHashSet<u64> {


### PR DESCRIPTION
This PR is needed to adapt the routing engine code to [this change](https://github.com/florianburgener/hrdf-parser/pull/2) in the hrdf-parser crate. It is also useful to treat the case of being unable to find an id in the ResourceStorage types.